### PR TITLE
Add state information to address if necessary and served by osm

### DIFF
--- a/CRM/Utils/Geocode/OpenStreetMapCoding.php
+++ b/CRM/Utils/Geocode/OpenStreetMapCoding.php
@@ -179,7 +179,7 @@ class CRM_Utils_Geocode_OpenStreetMapCoding {
       $state = isset($json[0]->address) ? $json[0]->address->state : "";
       $hasState = isset($values['state_province_id']) && $values['state_province_id'] != "null";
       if (isset($state) && !$hasState) {
-        $values['state_province_id'] = self::getStateId($state, $params["country_id"]);
+        $values['state_province_id'] = self::getStateId($state, isset($params["country_id"]) ? $params["country_id"] : "");
       }
 
       return TRUE;


### PR DESCRIPTION
Updates address with state information if it's unset and nominatim serves it.

Also adjusts maximum decimal places on lat/lon values to 10 to not exceed civi's field limit of 14.

I removed the TODO comment because I don't think any other fields nominatim propagates are useful. And if some will be, developers recognizing it may have a fresh look at nominatims portfolio.
