### PR TITLE
PHP 8.1 compatibility - don't pass stdObject as array to array_key_exists

### DIFF
--- a/CRM/Utils/Geocode/OpenStreetMapCoding.php
+++ b/CRM/Utils/Geocode/OpenStreetMapCoding.php
@@ -191,7 +191,7 @@ class CRM_Utils_Geocode_OpenStreetMapCoding {
 
       // Process results
       $string = $request->getBody();
-      $json = json_decode($string);
+      $json = json_decode($string, TRUE);
     }
 
     if (is_null($json) || !is_array($json)) {


### PR DESCRIPTION
Per the PHP docs on array_key_exists:
```
Note:

    For backward compatibility reasons, array_key_exists() will also return true if key is a property defined within an object given as array. This behaviour is deprecated as of PHP 7.4.0, and removed as of PHP 8.0.0.

    To check whether a property exists in an object, [property_exists()](https://www.php.net/manual/en/function.property-exists.php) should be used.
```

`decode_json()` will return an array instead of a stdObject if you pass `TRUE` as the second argument.

Without this fix, you'll get this error:
```
php TypeError: array_key_exists(): Argument #2 ($array) must be of type array, stdClass given in CRM_Utils_Geocode_OpenStreetMapCoding::format() (line 169 of /var/www/mysite/web/sites/all/civicrm/extensions/de.systopia.osm/CRM/Utils/Geocode/OpenStreetMapCoding.php) #0 /var/www/mysite/vendor/civicrm/civicrm-core/CRM/Core/BAO/Address.php(1312): CRM_Utils_Geocode_OpenStreetMapCoding::format()
```

(Ignore the line number in my error - I'm using an outdated version but the problem exists on the master branch also)