### PR TITLE
Fix URL for getCoordinates API

### DIFF
--- a/CRM/Utils/Geocode/OpenStreetMapCoding.php
+++ b/CRM/Utils/Geocode/OpenStreetMapCoding.php
@@ -146,7 +146,7 @@ class CRM_Utils_Geocode_OpenStreetMapCoding {
   }
 
   public static function getCoordinates($address): array {
-    return self::makeRequest(urlencode($address));
+    return self::makeRequest("https://" . self::$_server . self::$_uri . '?format=json&q=' . urlencode($address));
   }
 
   /**


### PR DESCRIPTION
This aims to fix the URL that is passed through to makeRequest when executing an APIv4 Address.getCoordinates API call

At the moment makeRequest is expecting a fully formed url to be passed through but all we are passing through is the address urlencoded see L136 and L158