### PR TITLE
Fix mkdocs config standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Therefore we recommend that you consider using the throttling option for the
 "Geocode and Parse Adresses" cronjob if processing data sets containing more
 than 10.000 addresses.
 
-Find the [German README here](docs/german.md).
+Find the [German README here](./german.md).
 
 Remark: Be careful when activating the "Geocode and Parse Addresses" scheduled
 job. It will try to look up all addresses that have not been geocoded yet. That,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: OpenStreetMap CiviCRM GeoCoder
 repo_url: https://github.com/systopia/de.systopia.osm
-theme: material
+theme:
+  name: material
 
 nav:
 - Home: index.md


### PR DESCRIPTION
@jofranz 

This fixes the following error

"Cannot access offset of type string on string" 

```PHP
        // If we have a theme-customization directory which matches the theme used
        // in the book, then use these theme customizations when building.
        $theme = $config['theme']['name'];
        $this->themeCustomPath = "{$this->themeCustomPathRoot}/$theme"; 
        if ($this->fs->exists($this->themeCustomPath)) { 
           $config['theme']['custom_dir'] = $this->themeCustomPath;
        }
```